### PR TITLE
Fix favicon path.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,7 +9,7 @@ export default {
       { name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' },
       { hid: 'description', name: 'description', content: 'Lebab Modernizing Javascript Code' }
     ],
-    link: [ { rel: 'icon', type: 'image/x-icon', href: '/lebab-ce/favicon.ico' }, { href: babelUrl, rel: 'preload', as: 'script' } ],
+    link: [ { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }, { href: babelUrl, rel: 'preload', as: 'script' } ],
     script: [ { src: babelUrl, body: true } ]
   },
   css: [ '~/assets/scss/style.scss' ],


### PR DESCRIPTION
Untested but it should be OK.

Currently this is what's present:

```html
<link data-n-head="true" rel="icon" type="image/x-icon" href="/lebab-ce/favicon.ico">
```

But since the main domain is `https://lebab.unibtc.me/`, the above is 404.