### PR TITLE
Fix cors issue on Firefox

### DIFF
--- a/components/LebabReadme.vue
+++ b/components/LebabReadme.vue
@@ -9,7 +9,7 @@ export default {
     };
   },
   created(){
-    this.$axios.$get('https://raw.githubusercontent.com/lebab/lebab/master/README.md')
+    this.$axios.$get('https://cdn.staticaly.com/gh/lebab/lebab/master/README.md')
       .then((res) => {
         res = res.replace(/http:/g, 'https:');
         this.model = res;


### PR DESCRIPTION
Fixes https://github.com/uniibu/lebab-ce/issues/29
There seems to be a cors request issue as far as i can test on Firefox. It keeps triggering a pre-flight request which the url `raw.githubusercontent.com` does not allow. 

Using the same `cdn` that we use for the browserified lebab package, it will act as a proxy for us to fetch the `README.md` file from lebab.


Signed-off-by: unibtc <unibtc@gmail.com>